### PR TITLE
Explicit method for adding boundaries

### DIFF
--- a/boundary_iou/coco_instance_api/coco.py
+++ b/boundary_iou/coco_instance_api/coco.py
@@ -322,13 +322,13 @@ class COCO:
             for ann in anns:
                 print(ann['caption'])
 
-    def loadRes(self, resFile):
+    def loadRes(self, resFile, get_boundary=False):
         """
         Load result file and return a result api object.
         :param   resFile (str)     : file name of result file
         :return: res (obj)         : result api object
         """
-        res = COCO(get_boundary=self.get_boundary, dilation_ratio=self.dilation_ratio)
+        res = COCO(get_boundary=get_boundary, dilation_ratio=self.dilation_ratio)
         res.dataset['images'] = [img for img in self.dataset['images']]
 
         print('Loading and preparing results...')

--- a/boundary_iou/coco_instance_api/cocoeval.py
+++ b/boundary_iou/coco_instance_api/cocoeval.py
@@ -314,7 +314,7 @@ class COCOeval:
         gt = [gt[i] for i in gtind]
         dtind = np.argsort([-d['score'] for d in dt], kind='mergesort')
         dt = [dt[i] for i in dtind[0:maxDet]]
-        iscrowd = [int(o['iscrowd']) for o in gt]
+        iscrowd = [int(o.get('iscrowd', 0)) for o in gt]
         # load computed ious
         ious = self.ious[imgId, catId][:, gtind] if len(self.ious[imgId, catId]) > 0 else self.ious[imgId, catId]
 

--- a/boundary_iou/coco_instance_api/cocoeval.py
+++ b/boundary_iou/coco_instance_api/cocoeval.py
@@ -431,8 +431,8 @@ class COCOeval:
                     tps = np.logical_and(               dtm,  np.logical_not(dtIg) )
                     fps = np.logical_and(np.logical_not(dtm), np.logical_not(dtIg) )
 
-                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                    tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                    fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
                     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
                         tp = np.array(tp)
                         fp = np.array(fp)

--- a/boundary_iou/coco_instance_api/cocoeval.py
+++ b/boundary_iou/coco_instance_api/cocoeval.py
@@ -203,7 +203,7 @@ class COCOeval:
             raise Exception('unknown iouType for iou computation')
 
         # compute iou between each dt and gt region
-        iscrowd = [int(o['iscrowd']) for o in gt]
+        iscrowd = [int(o.get('iscrowd', 0)) for o in gt]
         ious = maskUtils.iou(d,g,iscrowd)
         return ious
     
@@ -231,7 +231,7 @@ class COCOeval:
         d_b = [d['boundary'] for d in dt]
 
         # compute iou between each dt and gt region
-        iscrowd = [int(o['iscrowd']) for o in gt]
+        iscrowd = [int(o.get('iscrowd', 0)) for o in gt]
         mask_ious = maskUtils.iou(d_m,g_m,iscrowd)
         boundary_ious = maskUtils.iou(d_b,g_b,iscrowd)
         # combine mask and boundary iou

--- a/boundary_iou/utils/boundary_utils.py
+++ b/boundary_iou/utils/boundary_utils.py
@@ -103,7 +103,7 @@ def add_boundary_multi_core(coco, cpu_num=16, dilation_ratio=0.02):
     print('`boundary` added! (t={:0.2f}s)'.format(time.time()- tic))
 
 
-def coco_add_boundaries_and_save_as_annotation_file(annotation_file: str):
+def coco_add_boundaries_and_save_as_annotation_file(annotation_file: str, stem_addon='_b'):
     # NOTE: we only need coco at the moment, feel free to generalize this function
     from ..coco_instance_api.coco import COCO
 
@@ -115,13 +115,13 @@ def coco_add_boundaries_and_save_as_annotation_file(annotation_file: str):
         coco_json = json.load(f)
 
     # boundary counts are byte strings, we need to decode them so they are json serializable
-    anns_wb = list(coco.anns.values())
-    for a in anns_wb:
+    anns_b = list(coco.anns.values())
+    for a in anns_b:
         a['boundary']['counts'] = a['boundary']['counts'].decode("utf-8")
-    coco_json['annotations'] = anns_wb
+    coco_json['annotations'] = anns_b
 
-    new_annotation_file = annotation_file.parent / (annotation_file.stem + "_wb.json")
+    new_annotation_file = annotation_file.parent / (annotation_file.stem + stem_addon + annotation_file.suffix)
     with open(new_annotation_file, 'w', encoding='utf-8') as f:
         json.dump(coco_json, f)
 
-    print(f"\nAdded boundaries to '{annotation_file.name}' and saved as: '{new_annotation_file.name}'")
+    print(f"\nAdded boundaries to ({annotation_file.parent}) '{annotation_file.name}' and saved as: '{new_annotation_file.name}'")


### PR DESCRIPTION
This PR adds an additional method to add boundaries without changing current behavior. 

It's very similar to the existing methods but can be invoked manually. Also, it allows to explicitly specify the number of cpus in the multiprocessing step. In our case, we get 4x faster conversion times by using `cpu_num` << `multiprocessing.cpu_count()` since IPC is very expensive and our system has many cores. Note that we also untangle the conversion of `cocoGt` and `cocoDt` by adding `get_boundary` as an argument to `loadRes` instead of following what was done in `cocoGt`. This actually does change the current behavior *slightly* but should be of no concern since `COCOeval` will run any missing conversion anyway. On the other hand, the user gains more flexibility and control of when to run the conversion!

The PR also includes as small fix for the deprecation warning np.float -> float

Let me know what you think :)
Best,
Johannes
